### PR TITLE
Support Python 2.6, 2.7, 3.3, Django 1.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ t
 .DS_Store
 docs/html/
 docs/doctrees/
+.tox

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url = 'http://amitu.com/importd/',
     license = 'BSD',
 
-    install_requires = ["fhurl", "gunicorn", "smarturls"],
+    install_requires = ["fhurl>=0.1.7", "gunicorn", "smarturls", "six"],
     py_modules = ["importd"],
 
     zip_safe = True,

--- a/tests/basic_tests/main.py
+++ b/tests/basic_tests/main.py
@@ -1,3 +1,6 @@
+# make sure to use importd from the repository
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from importd import d
 
 d(DEBUG=True, INSTALLED_APPS=["app"])

--- a/tests/model_tests/test_app.py
+++ b/tests/model_tests/test_app.py
@@ -1,3 +1,6 @@
+# make sure to use importd from the repository
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from importd import d
 
 d(INSTALLED_APPS=["app"])

--- a/tests/test_all
+++ b/tests/test_all
@@ -3,9 +3,9 @@
 set -e
 
 cd basic_tests
-python main.py test app
+python -E main.py test app # -E makes interpreter ignores PYTHONPATH envvar
 cd ..
 cd model_tests
-python test_app.py test app
+python -E test_app.py test app
 
 echo "All tests passed."

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[tox]
+downloadcache = {toxworkdir}/cache/
+envlist =
+    py26-django14,
+    py26-django15,
+    py27-django14,
+    py27-django15,
+    py33-django15,
+
+[testenv]
+changedir = tests
+commands =
+; ./test_all
+    python -E basic_tests/main.py test app
+    python -E model_tests/test_app.py test app
+
+[django14]
+deps = Django==1.4.5
+
+[django15]
+deps = Django==1.5
+
+[testenv:py26-django14]
+basepython = python2.6
+deps = {[django14]deps}
+
+[testenv:py26-django15]
+basepython = python2.6
+deps = {[django15]deps}
+
+[testenv:py27-django14]
+basepython = python2.7
+deps = {[django14]deps}
+
+[testenv:py27-django15]
+basepython = python2.7
+deps = {[django15]deps}
+
+[testenv:py33-django15]
+basepython = python3.3
+deps = {[django15]deps}
+
+


### PR DESCRIPTION
Currently I've updated project so it supports Python 2.6, 2.7 and 3.3 with Django 1.4+. More variations can be added to tox easily in future. Those would require some updates to importd but wanted those changes to be as small as possible at first.

Tox would run python scripts by itself and `test_all` shell script is probably not needed anymore (however I haven't removed it; it can still serve as shortcut to run tests on current environment, not needing to run whole tox).

**Note that I've added two lines to each of single django test apps so they use `importd` from repository and not the one installed globally or from `PYTHONPATH`.**
