### PR TITLE
Apply django admin after INSTALLED_APPS

### DIFF
--- a/importd/__init__.py
+++ b/importd/__init__.py
@@ -337,6 +337,26 @@ class D(object):
             urlpatterns = self.get_urlpatterns()
             urlpatterns += staticfiles_urlpatterns()
 
+            # django depends on INSTALLED_APPS's model
+            for app in settings.INSTALLED_APPS:
+                try:
+                    __import__("{}.admin".format(app))  # lint:ok
+                except ImportError:
+                    pass
+                try:
+                    __import__("{}.models".format(app))  # lint:ok
+                except ImportError:
+                    pass
+
+            if admin_url:
+                from django.contrib import admin
+                try:
+                    from django.conf.urls import include
+                except ImportError:
+                    from django.conf.urls.defaults import include  # lint:ok
+                admin.autodiscover()
+                self.add_view(admin_url, include(admin.site.urls))
+
             # import .views and .forms for each installed app
             for app in settings.INSTALLED_APPS:
                 try:
@@ -351,16 +371,6 @@ class D(object):
                     __import__("{}.signals".format(app))  # lint:ok
                 except ImportError:
                     pass
-
-            if admin_url:
-                from django.contrib import admin
-                try:
-                    from django.conf.urls import include
-                except ImportError:
-                    from django.conf.urls.defaults import include  # lint:ok
-                admin.autodiscover()
-                self.add_view(admin_url, include(admin.site.urls))
-
 
         self._configured = True
 


### PR DESCRIPTION
## Description

I use [django-relationships](https://github.com/coleifer/django-relationships) with debug=False.
This is code.

``` python
#!/usr/bin/env python
#-*- coding: utf-8 -*-

from importd import d

d(
    DEBUG=False,
    SITE_ID=1,
    ALLOWED_HOSTS=['*'],
    INSTALLED_APPS=(
        'django.contrib.sites',
        'relationships'
    )
)

@d("/")
def index(request):
    return d.HttpResponse("Hello World")

if __name__ == "__main__":
    d.main()
```

then error occur.

```
Traceback (most recent call last):
  File "app.py", line 11, in <module>
    'relationships'
  File "/home/haruna/develop/importd-admin-import/web/importd/__init__.py", line 392, in __call__
    self._configure_django(**kw)
  File "/home/haruna/develop/importd-admin-import/web/importd/__init__.py", line 346, in _configure_django
    admin.autodiscover()
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/contrib/admin/__init__.py", line 29, in autodiscover
    import_module('%s.admin' % app)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/relationships/admin.py", line 4, in <module>
    from .compat import User
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/relationships/compat.py", line 7, in <module>
    User = get_user_model()
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 127, in get_user_model
    user_model = get_model(app_label, model_name)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/db/models/loading.py", line 271, in get_model
    self._populate()
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/db/models/loading.py", line 78, in _populate
    self.load_app(app_name)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/db/models/loading.py", line 99, in load_app
    models = import_module('%s.models' % app_name)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/home/haruna/develop/importd-admin-import/web/.venv/local/lib/python2.7/site-packages/relationships/models.py", line 8, in <module>
    from .compat import User
ImportError: cannot import name User
```

from .compat import User.....from .compat import User !
Circular import occur!
## Solution

I think that this problem caused by import order.
First, apply all extra django library. Then apply django admin. 
In real django, this order is same. (Apply INSTALLED_APPS, then use urls.py + django-admin)
