### PR TITLE
Don't depend on gunicorn since it's not required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='BSD',
 
     install_requires=[
-        "fhurl>=0.1.7", "gunicorn", "smarturls", "six", "Django>=1.3",
+        "fhurl>=0.1.7", "smarturls", "six", "Django>=1.3",
         "dj-database-url",
     ],
     packages=["importd"],


### PR DESCRIPTION
How your project runs in production should not be dictated by the framework. If I want to deploy on uwsgi, I don't need to have gunicorn installed, for example.

So this dependency is just not needed.
