### PR TITLE
Add whitenoise to support Heroku.

### DIFF
--- a/importd/__init__.py
+++ b/importd/__init__.py
@@ -236,6 +236,13 @@ class D(object):
             self.wsgi_application = django.core.handlers.wsgi.WSGIHandler()
 
         try:
+            # https://devcenter.heroku.com/articles/django-assets
+            from whitenoise.django import DjangoWhiteNoise
+            self.wsgi_application = DjangoWhiteNoise(self.wsgi_application)
+        except ImportError:
+            pass
+
+        try:
             from django.conf.urls.defaults import patterns, url
         except ImportError:
             from django.conf.urls import patterns, url  # lint:ok

--- a/importd/__init__.py
+++ b/importd/__init__.py
@@ -417,14 +417,6 @@ class D(object):
                     0, "importd.SmartReturnMiddleware"
                 )
 
-            # for static assets serving in heroku
-            try:
-                import whitenoise
-                kw['STATICFILES_STORAGE'] = 'whitenoise.django.GzipManifestStaticFilesStorage'
-            except ImportError:
-                pass
-
-
             installed = list(kw.setdefault("INSTALLED_APPS", []))
 
             admin_url = kw.pop("admin", "^admin/")

--- a/importd/__init__.py
+++ b/importd/__init__.py
@@ -417,6 +417,14 @@ class D(object):
                     0, "importd.SmartReturnMiddleware"
                 )
 
+            # for static assets serving in heroku
+            try:
+                import whitenoise
+                kw['STATICFILES_STORAGE'] = 'whitenoise.django.GzipManifestStaticFilesStorage'
+            except ImportError:
+                pass
+
+
             installed = list(kw.setdefault("INSTALLED_APPS", []))
 
             admin_url = kw.pop("admin", "^admin/")


### PR DESCRIPTION
## Overview
If whitenoise is added to importd, it can run on heroku.
https://importd-boilerplate.herokuapp.com/

https://devcenter.heroku.com/articles/django-assets
> By default, Django does not support serving static files in production. We recommend using the WhiteNoise project for best-practice serving of static assets in production.

### why not STATICFILES_STORAGE ?
If set STATICFILES_STORAGE, whitenoise support gzip.
But It cause a problem. Cannot run unit test without `collectstatic`.
So, I didn't add `STATICFILES_STORAGE` to importd.
I think that appling whitenoise gzip or not is user's choice.
