### PR TITLE
Ability to access admin without explicitly declaring MIDDLEWARE_CLASSES.

### DIFF
--- a/importd/__init__.py
+++ b/importd/__init__.py
@@ -442,6 +442,9 @@ class D(object):
                     )
                 if "django.contrib.admin" not in installed:
                     installed.append("django.contrib.admin")
+                    kw["MIDDLEWARE_CLASSES"].append(
+                        "django.contrib.auth.middleware.AuthenticationMiddleware"
+                    )
                 if "django.contrib.humanize" not in installed:
                     installed.append("django.contrib.humanize")
                 if "django.contrib.staticfiles" not in installed:


### PR DESCRIPTION
Currently /admin gives 'WSGIRequest' object has no attribute 'user'.
This happened because AUTHENTICATION_MIDDLEWARE wasn't added in
MIDDLEWARE_CLASSES. This commit fixes the issue.